### PR TITLE
Add option excludeText for transform TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Generate table of contents from markdown file
 - `firsth1` - *Boolean* - (optional): Show first h1 of doc in table of contents. Default `false`
 - `collapse` - *Boolean* - (optional): Collapse the table of contents in a detail accordian. Default `false`
 - `collapseText` - *string* - (optional): Text the toc accordian summary
+- `excludeText` - *string* - (optional): Text to exclude in the table of contents. Default `Table of Contents`
 
 **Example:**
 ```md

--- a/lib/transforms/index.js
+++ b/lib/transforms/index.js
@@ -53,6 +53,7 @@ const transforms = {
    * - `firsth1` - *Boolean* - (optional): Show first h1 of doc in table of contents. Default `false`
    * - `collapse` - *Boolean* - (optional): Collapse the table of contents in a detail accordian. Default `false`
    * - `collapseText` - *string* - (optional): Text the toc accordian summary
+   * - `excludeText` - *string* - (optional): Text to exclude in the table of contents. Default `Table of Contents`
    *
    * **Example:**
    * ```md

--- a/lib/transforms/toc.js
+++ b/lib/transforms/toc.js
@@ -1,14 +1,12 @@
 const toc = require('markdown-toc')
 
-function removeJunk(str, ele, arr) {
-  return str.indexOf('Table of Contents') === -1;
-}
-
 module.exports = function TOC(content, options, config) {
   const opts = options || {}
   /* https://github.com/jonschlinkert/markdown-toc#options */
   const tocOpts = {
-    filter: removeJunk,
+    filter: function removeJunk(str, ele, arr) {
+      return str.indexOf((opts.excludeText) ? opts.excludeText : 'Table of Contents') === -1
+    },
     firsth1: opts.firsth1 || false
   }
   const t = toc(config.outputContent, tocOpts)


### PR DESCRIPTION
This allows to choose the text to exclude in the table of contents. This is useful if the text is not equal to `Table of Contents`  