### PR TITLE
add 'use strict'

### DIFF
--- a/lib/updateContents.js
+++ b/lib/updateContents.js
@@ -1,4 +1,4 @@
-
+'use strict';
 /*
  Update contents between Comment tags
 */


### PR DESCRIPTION
Because of lack of 'use strict' node 5 throws `SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`