### PR TITLE
Handle characters `=` contained in an option of a transform

### DIFF
--- a/lib/updateContents.js
+++ b/lib/updateContents.js
@@ -56,7 +56,7 @@ function parseOptions(options) {
   }
   const returnOptions = {}
   options.split('&').map((opt, i) => { // eslint-disable-line
-    const getValues = opt.split('=')
+    const getValues = opt.split(/=(.+)/)
     if (getValues[0] && getValues[1]) {
       returnOptions[getValues[0]] = getValues[1]
     }

--- a/test/fixtures/TOC-test.md
+++ b/test/fixtures/TOC-test.md
@@ -1,0 +1,34 @@
+# Test for TOC
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC) - Test #1: without option and the content with empty line  -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me) - Test #2: with collapse options and the content with 'aaaaaaaaa'  -->
+aaaaaaaaa
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) - Test #3: with collapseText contains character '='  -->
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+
+## Title A
+
+Text A
+
+### Subtitle z
+
+Text Z
+
+### Subtitle x
+
+Text X
+
+## Title B
+
+Text B
+
+## Title C
+
+Text B

--- a/test/test.js
+++ b/test/test.js
@@ -80,6 +80,62 @@ test('if config.matchWord supplied, use it for comment matching', t => {
   fs.emptyDirSync(outputDir)
 })
 
+test('<!-- AUTO-GENERATED-CONTENT:START (TOC)-->', t => {
+  const filePath = path.join(__dirname, 'fixtures', 'TOC-test.md')
+  const config = {
+    outputDir: outputDir
+  }
+  markdownMagic(filePath, config)
+  const newfile = path.join(config.outputDir, 'TOC-test.md')
+  const newContent = fs.readFileSync(newfile, 'utf8')
+
+  const expectedTest1 = `
+<!-- AUTO-GENERATED-CONTENT:START (TOC) - Test #1: without option and the content with empty line  -->
+- [Title A](#title-a)
+  * [Subtitle z](#subtitle-z)
+  * [Subtitle x](#subtitle-x)
+- [Title B](#title-b)
+- [Title C](#title-c)
+<!-- AUTO-GENERATED-CONTENT:END -->`
+  const regexTest1 = new RegExp(`(?=${expectedTest1.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')})`, "i")
+  t.regex(newContent, regexTest1, 'Test #1 : without option and the content with empty line')
+
+  const expectedTest2 = `
+<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me) - Test #2: with collapse options and the content with 'aaaaaaaaa'  -->
+<details>
+<summary>Click Me</summary>
+
+- [Title A](#title-a)
+  * [Subtitle z](#subtitle-z)
+  * [Subtitle x](#subtitle-x)
+- [Title B](#title-b)
+- [Title C](#title-c)
+
+</details>
+<!-- AUTO-GENERATED-CONTENT:END -->`
+  const regexTest2 = new RegExp(`(?=${expectedTest2.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')})`, "i")
+  t.regex(newContent, regexTest2, "Test #2: with collapse options and the content with 'aaaaaaaaa'")
+
+  const expectedTest3 = `
+<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) - Test #3: with collapseText contains character '='  -->
+<details>
+<summary>Click Me=I have the power</summary>
+
+- [Title A](#title-a)
+  * [Subtitle z](#subtitle-z)
+  * [Subtitle x](#subtitle-x)
+- [Title B](#title-b)
+- [Title C](#title-c)
+
+</details>
+<!-- AUTO-GENERATED-CONTENT:END -->`
+  const regexTest3 = new RegExp(`(?=${expectedTest3.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')})`, "i")
+  t.regex(newContent, regexTest3, "Test #3: with collapseText contains character '='")
+
+  // remove test file after assertion
+  fs.emptyDirSync(outputDir)
+})
+
 /**
  * Test Built in transforms
  */


### PR DESCRIPTION
# Problem

If one or more characters `=` are in an transform option, when rendering, the characters after the first `=` (as well as the `=` character) are not rendered.

## Sample
For example with transform TOC, we have `README.md` file:

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->

<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Expected result

The expected result should be:

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<details>
<summary>Click Me=I have the power</summary>

- [Title A](#title-a)
- [Title B](#title-b)

</details>
<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Result

Unfortunately the result is not correct (missing`=I have the power` in tag `<summary>`):

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<details>
<summary>Click Me</summary>

- [Title A](#title-a)
- [Title B](#title-b)

</details>
<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

# Solution

The **first commit** add more tests to demonstrate the problem. (The [link](https://travis-ci.org/DavidWells/markdown-magic/builds/263485530#L870) to Travis-CI before the second commit that fixes the problem)

The **[second commit](https://github.com/DavidWells/markdown-magic/pull/20/commits/42fcd13019c8e7f09ae67184dfda2add0e5952e9)** fix the problem.