### PR TITLE
Handle empty line

### DIFF
--- a/lib/updateContents.js
+++ b/lib/updateContents.js
@@ -113,7 +113,7 @@ function getClosingTags(block, config) {
     console.log('closeTag End', "'"+matches[2]+"'");
     /**/
     return {
-      closeTag: matches[0],
+      closeTag: matches[1] + matches[2],
       closeTagStart: matches[1],
       closeTagEnd: matches[2]
     }

--- a/lib/utils/regex.js
+++ b/lib/utils/regex.js
@@ -11,6 +11,6 @@ module.exports.matchOpeningCommentTag = function (matchWord) {
 }
 
 module.exports.matchClosingCommentTag = function (matchWord) {
-  return new RegExp(`((?:\\<\\!--(?:.*|\\r?\\n)(?:.*|\\r?\\n))*?${matchWord}:END)((?:.|\\r?\\n)*?--\\>)`, 'g')
+  return new RegExp(`--\\>(?:.|\\r?\\n)*?((?:\\<\\!--(?:.*|\\r?\\n)(?:.*|\\r?\\n))*?${matchWord}:END)((?:.|\\r?\\n)*?--\\>)`, 'g')
 }
 

--- a/test/fixtures/TOC-test.md
+++ b/test/fixtures/TOC-test.md
@@ -12,6 +12,11 @@ aaaaaaaaa
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
+<!-- AUTO-GENERATED-CONTENT:START (TOC) - Test #4: without option and the content is empty  -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC) - Test #5: without option and tags with same line  --><!-- AUTO-GENERATED-CONTENT:END -->
+
 
 ## Title A
 

--- a/test/test.js
+++ b/test/test.js
@@ -132,6 +132,28 @@ test('<!-- AUTO-GENERATED-CONTENT:START (TOC)-->', t => {
   const regexTest3 = new RegExp(`(?=${expectedTest3.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')})`, "i")
   t.regex(newContent, regexTest3, "Test #3: with collapseText contains character '='")
 
+  const expectedTest4 = `
+<!-- AUTO-GENERATED-CONTENT:START (TOC) - Test #4: without option and the content is empty  -->
+- [Title A](#title-a)
+  * [Subtitle z](#subtitle-z)
+  * [Subtitle x](#subtitle-x)
+- [Title B](#title-b)
+- [Title C](#title-c)
+<!-- AUTO-GENERATED-CONTENT:END -->`
+  const regexTest4 = new RegExp(`(?=${expectedTest4.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')})`, "i")
+  t.regex(newContent, regexTest4, 'Test #4 : without option and the content is empty')
+
+  const expectedTest5 = `
+<!-- AUTO-GENERATED-CONTENT:START (TOC) - Test #5: without option and tags with same line  -->
+- [Title A](#title-a)
+  * [Subtitle z](#subtitle-z)
+  * [Subtitle x](#subtitle-x)
+- [Title B](#title-b)
+- [Title C](#title-c)
+<!-- AUTO-GENERATED-CONTENT:END -->`
+  const regexTest5 = new RegExp(`(?=${expectedTest5.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')})`, "i")
+  t.regex(newContent, regexTest5, 'Test #5 : without option and tags with same line')
+
   // remove test file after assertion
   fs.emptyDirSync(outputDir)
 })


### PR DESCRIPTION
# Problem

* if we have a empty line between the open and close tag, the opening tag is repeated after adding the content
* if we are on the same line between the opening and closing tag, the opening tag is repeated after adding the content

## Sample "empty line"
For example with transform TOC, we have `README.md` file:

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Expected result "empty line"

The expected result should be:

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<details>
<summary>Click Me=I have the power</summary>

- [Title A](#title-a)
- [Title B](#title-b)

</details>
<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Result "empty line"

Unfortunately the result is not correct (the opening tag is repeated after adding the content):

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<details>
<summary>Click Me=I have the power</summary>

- [Title A](#title-a)
- [Title B](#title-b)

</details>
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Sample "same line"
For example with transform TOC, we have `README.md` file:

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) --><!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Expected result "same line"

The expected result should be:

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<details>
<summary>Click Me=I have the power</summary>

- [Title A](#title-a)
- [Title B](#title-b)

</details>
<!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

## Result "same line"

Unfortunately the result is not correct (the opening tag is repeated after adding the content):

```markdown
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) -->
<details>
<summary>Click Me=I have the power</summary>

- [Title A](#title-a)
- [Title B](#title-b)

</details>
<!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText=Click Me=I have the power) --><!-- AUTO-GENERATED-CONTENT:END -->

## Title A

## Title B
```

# Solution

The **first commit** add more tests to demonstrate the problem.

The **second commit** fix this problem