### PR TITLE
Preserve indentation

### DIFF
--- a/lib/processFile.js
+++ b/lib/processFile.js
@@ -68,7 +68,8 @@ module.exports = function processFile(filePath, config) {
       const command = `Transform ${commentMatches[1]}` // eslint-disable-line
       // console.log(command)
       transformsFound.push({
-        transform: commentMatches[1],
+        spaces: commentMatches[1], // Preserve indentation
+        transform: commentMatches[2],
         match: match[matchIndex]
       })
       // wait
@@ -87,7 +88,12 @@ module.exports = function processFile(filePath, config) {
       transformMsg += `  ⁕ ${element.transform} \n`
       // console.log('order', element.transform)
       const newContent = updateContents(element.match, mergedConfig)
-      content = content.replace(element.match, newContent)
+
+      const firstLineIndentation = element.spaces
+      const contentWithIndentation = newContent.split('\n').join(`\n` + element.spaces)
+      const preserveTabs = `${firstLineIndentation}${contentWithIndentation}`
+
+      content = content.replace(element.match, preserveTabs)
       mergedConfig.outputContent = content
     })
 

--- a/lib/utils/regex.js
+++ b/lib/utils/regex.js
@@ -2,7 +2,7 @@
 /*eslint-disable */
 module.exports.matchCommentBlock = function(matchWord) {
   //return new RegExp(`(?:\\<\\!--(?:.|\\r?\\n)*?${matchWord}:START(?:.|\\r?\\n)*?\\()(.*)\\)(?:.|\\r?\\n)*?<!--(?:.|\\r?\\n)*?${matchWord}:END(?:.|\\r?\\n)*?--\\>`, 'g')
-  return new RegExp(`(?:\\<\\!--(?:.*|\r?|\n?|\s*)${matchWord}:START(?:.|\\r?\\n)*?\\()(.*)\\)(?:.|\\r?\\n)*?<!--(?:.*|\r?|\n?|\s*)${matchWord}:END(?:.|\\r?\\n)*?--\\>`, 'g')
+  return new RegExp(`(.*)(?:\\<\\!--(?:.*|\r?|\n?|\s*)${matchWord}:START(?:.|\\r?\\n)*?\\()(.*)\\)(?:.|\\r?\\n)*?<!--(?:.*|\r?|\n?|\s*)${matchWord}:END(?:.|\\r?\\n)*?--\\>`, 'g')
 }
 
 module.exports.matchOpeningCommentTag = function (matchWord) {


### PR DESCRIPTION
This PR matches line indentation and preserves them for transforms.

Before this indented transform was

```
    words words words

    <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./functions/todos-create.js) -->
    <!-- The below code snippet is automatically added from ./functions/todos-create.js -->
     code will go here
    <!-- AUTO-GENERATED-CONTENT:END -->
```

Was tranforming to 

```
    words words words

<!-- AUTO-GENERATED-CONTENT:START (CODE:src=./functions/todos-create.js) -->
<!-- The below code snippet is automatically added from ./functions/todos-create.js -->
\`\`\`js
⊂◉‿◉つ
\`\`\`
<!-- AUTO-GENERATED-CONTENT:END -->
```

Now spaces get preserved. Handy and needed for indented readme files.

Now: 

```
    words words words

    <!-- AUTO-GENERATED-CONTENT:START (CODE:src=./functions/todos-create.js) -->
    <!-- The below code snippet is automatically added from ./functions/todos-create.js -->
     \`\`\`js
     ⊂◉‿◉つ
     \`\`\`
    <!-- AUTO-GENERATED-CONTENT:END -->
```
