### PR TITLE
Add stripTags option to remove markdown-magic tags from output files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ markdownMagic(filePath, config, callback)
 
 - `matchWord` - *string* - (optional) Comment pattern to look for & replace inner contents. Default `AUTO-GENERATED-CONTENT`
 
+- `stripTags` - *Boolean* - (optional) set strip tags to `true` to remove tags from the output file. It's highly recommended to set a distinct `outputDir` in this case. Default behavior leaves the matched tags in place.
+
 - `DEBUG` - *Boolean* - (optional) set debug flag to `true` to inspect the process
 <!-- ⛔️ MD-MAGIC-EXAMPLE:END - Do not remove or modify this section -->
 

--- a/lib/updateContents.js
+++ b/lib/updateContents.js
@@ -45,9 +45,13 @@ module.exports = function updateContents(block, config) {
     newContent = originalContent
   }
 
+  if (config.stripTags === true){
+    return `${newContent}`
+  }else {
   return `${openingTag.openTag}
 ${newContent}
 ${closingTag.closeTag}`
+  }
 }
 
 function parseOptions(options) {


### PR DESCRIPTION
When generating markdown for certain cases the HTML comment tags might wind up rendered. It was a quick and easy fix to remove the tags in the presence of a certain configuration option.

No change by default.