### PR TITLE
remove duplicated `local-image` entry in  `🔌 Markdown magic plugins`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,6 @@ The face symbol 👉 <!-- MD-MAGIC-EXAMPLE:START (INLINE_EXAMPLE) -->**⊂◉‿
 * [jsdoc](https://github.com/bradtaylorsf/markdown-magic-jsdoc) - Adds jsdoc comment support
 * [build-badge](https://github.com/rishichawda/markdown-magic-build-badge) - Update branch badges to auto-magically point to current branches.
 * [package-json](https://github.com/forresst/markdown-magic-package-json) - Add the package.json properties to markdown files
-* [local-image](https://github.com/stevenbenisek/markdown-magic-local-image)
 * [figlet](https://github.com/lafourchette/markdown-magic-figlet) - Add FIGfont text to markdown files
 * [local-image](https://github.com/stevenbenisek/markdown-magic-local-image) - plugin to add local images to markdown
 


### PR DESCRIPTION
The `local-image` plugin is listed twice