### PR TITLE
#62 Replace require() with import() to comply with doctoc package change

### DIFF
--- a/lib/transforms/toc.js
+++ b/lib/transforms/toc.js
@@ -1,4 +1,4 @@
-const { transform } = require('@technote-space/doctoc')
+const { transform } = import('@technote-space/doctoc')
 const { removeLeadingAndTrailingLineBreaks } = require('../utils/regex')
 
 module.exports = async function TOC(content, options, config) {


### PR DESCRIPTION
This should contribute to fixing #62 

Seems like more things needs to happen though, because performing this change locally allowed me to build the README file but also came with new errors:

```
The auto-generating of rules finished!
(node:15640) UnhandledPromiseRejectionWarning: SyntaxError: Unexpected token '.'
    at Loader.moduleStrategy (internal/modules/esm/translators.js:140:18)
    at async link (internal/modules/esm/module_job.js:42:21)
(node:15640) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:15640) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Since I am not familiar with the codebase of this package I could use some help here.