### PR TITLE
Fix CLI --config parameter

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -80,5 +80,5 @@ function defaultCallback(err, msg) {
 }
 
 function getConfigFilepath() {
-  return program.config || findUp.sync(defaultConfigPath) || findUp.sync('md-magic.config.js')
+  return program.opts().config || findUp.sync(defaultConfigPath) || findUp.sync('md-magic.config.js')
 }


### PR DESCRIPTION
Currently when providing a custom config file via the `--config` parameter, this was never used.
This PR fixes this small issue.