### PR TITLE
Fix incorrect link in README for markdown-magic project examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ This will replace all the contents of inside the comment DUDE
 
 ## Usage examples
 
-- [Project using markdown-magic](https://github.com/search?o=desc&q=filename%3Apackage.json+%22markdown-magic%22&s=indexed&type=Code)
+- [Projects using markdown-magic](https://github.com/search?q=path%3A**%2Fpackage.json+%22markdown-magic%22&type=code)
 - [Examples in md](https://github.com/search?l=Markdown&o=desc&q=AUTO-GENERATED-CONTENT&s=indexed&type=Code)
 
 


### PR DESCRIPTION
This PR fixes the broken link in the README that points to projects using markdown-magic. The original URL was incorrect, and it has been updated.

**Before:**
<img width="1440" alt="Captura de Tela 2024-11-08 às 17 04 16" src="https://github.com/user-attachments/assets/58d8f92c-13d2-4e13-a3fe-7958df29d37d">


**After:**
<img width="1440" alt="Captura de Tela 2024-11-08 às 17 04 23" src="https://github.com/user-attachments/assets/44f367cb-535d-42bc-b4eb-5e644136a6f8">
