### PR TITLE
⬆️ bump ansi-styles, fix import for ESM

### DIFF
--- a/packages/core/_tests/fixtures/md/transform-file/shift-headers.md
+++ b/packages/core/_tests/fixtures/md/transform-file/shift-headers.md
@@ -132,7 +132,7 @@ function matchInnerContent(str, open, close) {
     "sync-request": "^6.1.0"
   },
   "devDependencies": {
-    "ansi-styles": "^4.2.1",
+    "ansi-styles": "^6.0.0",
     "concordance": "^5.0.1",
     "doxxx": "^2.0.7",
     "rimraf": "^3.0.2",

--- a/packages/core/_tests/utils/diff.js
+++ b/packages/core/_tests/utils/diff.js
@@ -1,5 +1,5 @@
 const concordance = require('concordance')
-const ansiStyles = require('ansi-styles')
+const ansiStyles = require('ansi-styles').default
 const chalk = require('./chalk')
 
 const colorTheme = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "sync-request": "^6.1.0"
   },
   "devDependencies": {
-    "ansi-styles": "^4.2.1",
+    "ansi-styles": "^6.0.0",
     "concordance": "^5.0.1",
     "doxxx": "^2.0.7",
     "rimraf": "^3.0.2",

--- a/packages/core/src/utils/logs.js
+++ b/packages/core/src/utils/logs.js
@@ -1,5 +1,5 @@
 const util = require('util')
-const ansi = require('ansi-styles') // https://github.com/chalk/ansi-styles/blob/main/index.js
+const ansi = require('ansi-styles').default // https://github.com/chalk/ansi-styles/blob/main/index.js
 const process = require('process')
 
 function convertHrtime(hrtime) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
         version: 6.1.0
     devDependencies:
       ansi-styles:
-        specifier: ^4.2.1
-        version: 4.3.0
+        specifier: ^6.0.0
+        version: 6.2.1
       concordance:
         specifier: ^5.0.1
         version: 5.0.4


### PR DESCRIPTION
we have an issue where another dependency is pulling in `ansi-styles` and due to dedupe/hoisting markdown-magic gets v6 and throws due to ansi-styles going ESM-only in v6

this PR upgrades to v6 and makes the necessary import change

[tests passing](https://github.com/ctcpip/markdown-magic/actions/runs/19285085169/job/55144083063?pr=1)
